### PR TITLE
Populate user order data from order patch request

### DIFF
--- a/app/routes/order_routes.js
+++ b/app/routes/order_routes.js
@@ -70,6 +70,10 @@ router.patch('/orders/:id', requireToken, removeBlanks, (req, res, next) => {
       order.set(req.body.order)
       return user.save()
     })
+    // if that succeeded, populate the orders' products on the returned user
+    .then(user => {
+      return user.populate('orders.products').execPopulate()
+    })
     // if that succeeded, return 201 and user's orders
     .then(user => res.status(201).json({orders: user.orders}))
     // if an error occurs, pass it to the handler


### PR DESCRIPTION
Add a .populate('orders.products') on the user returned from the patch request
Now a returned user from a order patch request contains all product data for their orders